### PR TITLE
パンくずリスト

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'jbuilder', '~> 2.5'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
-
+gem "gretel"
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,9 @@ GEM
       sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (4.1.0)
+      actionview (>= 5.1, < 7.0)
+      railties (>= 5.1, < 7.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     io-like (0.3.1)
@@ -227,6 +230,7 @@ DEPENDENCIES
   data-confirm-modal
   devise
   font-awesome-sass
+  gretel
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/app/views/layouts/_breadcrumbs.html.erb
+++ b/app/views/layouts/_breadcrumbs.html.erb
@@ -1,0 +1,6 @@
+<div class="breadcrumbs">
+  <div class="home_icon">
+    <i class="fas fa-home"></i>
+  </div>
+  <%= breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list" %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,6 @@
 
   <body>
     <%= render 'layouts/header' %>
-    <p><%= breadcrumbs separator: "＆rsaquo;"%></p>
     <div class="wrapper">
       <%= yield %>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
 
   <body>
     <%= render 'layouts/header' %>
+    <p><%= breadcrumbs separator: "＆rsaquo;"%></p>
     <div class="wrapper">
       <%= yield %>
     </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,4 +1,6 @@
 <div class="post_wrapper">
+  <% breadcrumb :post_edit, @post %>
+  <%= render "layouts/breadcrumbs" %>
   <div class="post_wrapper__content">
     <div class="post_wrapper__content__post_form">
       <h3>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,3 @@
-<% breadcrumb :post %>
 <div class="post_wrapper">
   <div class="post_wrapper__header">
     <h3>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :post %>
 <div class="post_wrapper">
   <div class="post_wrapper__header">
     <h3>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,6 @@
 <div class="post_wrapper">
+  <% breadcrumb :post_show, @post %>
+  <%= render "layouts/breadcrumbs" %>
   <div class="post_wrapper__header">
     <h3>
       <span>投稿詳細</span>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,30 +2,16 @@ crumb :root do
   link "投稿一覧", root_path
 end
 
-crumb :post do
-  link "投稿詳細", post_path
+crumb :post_new do
+  link "新規投稿", new_post_path
 end
-# crumb :projects do
-#   link "Projects", projects_path
-# end
 
-# crumb :project do |project|
-#   link project.name, project_path(project)
-#   parent :projects
-# end
+crumb :post_show do |post|
+  link "#{post.user.name}さんの投稿", post_path
+  parent :root
+end
 
-# crumb :project_issues do |project|
-#   link "Issues", project_issues_path(project)
-#   parent :project, project
-# end
-
-# crumb :issue do |issue|
-#   link issue.title, issue_path(issue)
-#   parent :project_issues, issue.project
-# end
-
-# If you want to split your breadcrumbs configuration over multiple files, you
-# can create a folder named `config/breadcrumbs` and put your configuration
-# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
-# folder are loaded and reloaded automatically when you change them, just like
-# this file (`config/breadcrumbs.rb`).
+crumb :post_edit do |post|
+  link "#{post.user.name}さんの投稿の編集", edit_post_path
+  parent :root
+end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,28 @@
+crumb :root do
+  link "投稿一覧", root_path
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,6 +2,9 @@ crumb :root do
   link "投稿一覧", root_path
 end
 
+crumb :post do
+  link "投稿詳細", post_path
+end
 # crumb :projects do
 #   link "Projects", projects_path
 # end


### PR DESCRIPTION
追加タスクのパンくずリストを実装
-サンプル同様に動作すること確認済
-テンプレートの_breadcrumpパーシャルを使用
-gem gretelを新たにインストール
-post new/editにパンくずリストを追加